### PR TITLE
Make grayscale swatch toggleable

### DIFF
--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -1,16 +1,15 @@
 // = require_tree .
 
-
 $(document).ready(function () {
   $('.color-swatches .swatch').click(function () {
-  	var color = $(this).data('color');
-  	$('#themed').remove();
+    var color = $(this).data('color');
+    $('#themed').remove();
     $('head').append('<link rel="stylesheet" href="stylesheets/'+color+'.css" type="text/css" id="themed" />');
-	});
+  });
 
-    $('.partymode').click(function () {
-    $('body').toggleClass('party');
-    });
+  $('.partymode').click(function () {
+  $('body').toggleClass('party');
+  });
 });
 
 // Smooth Scroll

--- a/source/javascripts/all.js
+++ b/source/javascripts/all.js
@@ -3,8 +3,17 @@
 $(document).ready(function () {
   $('.color-swatches .swatch').click(function () {
     var color = $(this).data('color');
-    $('#themed').remove();
-    $('head').append('<link rel="stylesheet" href="stylesheets/'+color+'.css" type="text/css" id="themed" />');
+    if (color === 'grayscale') {
+      if ($('#themed-gray').length) {
+        $('#themed-gray').remove();
+      } else {
+        $('head').append('<link rel="stylesheet" href="stylesheets/grayscale.css" type="text/css" id="themed-gray" />');
+      }
+    } else {
+      $('#themed-gray').remove();
+      $('#themed').remove();
+      $('head').append('<link rel="stylesheet" href="stylesheets/'+color+'.css" type="text/css" id="themed" />');
+    }
   });
 
   $('.partymode').click(function () {


### PR DESCRIPTION
The grayscale swatch in the "Contrast is key" section should be a toggle button so the following section can still be viewed in color.
![Grayscale swatch](https://cloud.githubusercontent.com/assets/4331946/24065621/ce168f1c-0b6c-11e7-8417-20cea4b41466.gif)

Fixes #13